### PR TITLE
fix(topology): close DOT file handle in TopologyApi.create()

### DIFF
--- a/air_sdk/topology.py
+++ b/air_sdk/topology.py
@@ -180,7 +180,11 @@ class TopologyApi:
             if isinstance(kwargs['dot'], io.IOBase):
                 payload = kwargs['dot']
             elif os.path.isfile(kwargs['dot']):
-                payload = open(kwargs['dot'], 'r').read()
+                dot_file = open(kwargs['dot'], 'r')
+                try:
+                    payload = dot_file.read()
+                finally:
+                    dot_file.close()
             else:
                 payload = kwargs['dot'].encode('utf-8')
             res = self.client.post(self.url, data=payload, headers={'Content-type': 'text/vnd.graphviz'})

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -6,7 +6,11 @@ Tests for topology.py
 """
 
 # pylint: disable=missing-function-docstring,missing-class-docstring,unused-argument
+import gc
 import io
+import os
+import tempfile
+import warnings
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -141,6 +145,32 @@ class TestTopologyApi(TestCase):
         self.assertEqual(res.id, 'abc')
         mock_isfile.assert_called_once_with(file_path)
         mock_open.assert_called_once_with(file_path, 'r')
+
+    @patch('air_sdk.util.raise_if_invalid_response')
+    def test_create_dot_file_path_closes_handle(self, *args):
+        # Regression test: creating a topology from a DOT file path must not
+        # leak the file handle (previously `open(path, 'r').read()` left the
+        # handle to be closed by the garbage collector, raising a
+        # ResourceWarning for the unclosed file).
+        self.client.post.return_value.json.return_value = {'id': 'abc'}
+        with tempfile.NamedTemporaryFile('w', suffix='.dot', delete=False) as tmp:
+            tmp.write('graph { a -- b }')
+            file_path = tmp.name
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                res = self.api.create(dot=file_path)
+                gc.collect()
+            leaked = [w for w in caught if issubclass(w.category, ResourceWarning)]
+            self.assertEqual(leaked, [], 'DOT file handle was not closed')
+            self.client.post.assert_called_with(
+                f'{self.client.api_url}/topology/',
+                data='graph { a -- b }',
+                headers={'Content-type': 'text/vnd.graphviz'},
+            )
+            self.assertEqual(res.id, 'abc')
+        finally:
+            os.unlink(file_path)
 
     @patch('air_sdk.util.raise_if_invalid_response')
     def test_create_dot_extra_kwargs(self, *args):


### PR DESCRIPTION
## Summary

`TopologyApi.create()` leaked the file handle when the `dot` argument was a path to a DOT file on disk. The file was opened inline and never closed.

## Root cause

```python
elif os.path.isfile(kwargs['dot']):
    payload = open(kwargs['dot'], 'r').read()
```

The temporary file object returned by `open()` is discarded after `.read()`, relying on CPython refcounting to close it. On other runtimes (e.g. PyPy) the handle leaks until garbage collection, and CPython emits a `ResourceWarning` for the unclosed file.

## Fix

Bind the file object to a name and close it deterministically in a `try/finally` block, keeping the existing `open(path, 'r')` call contract:

```python
dot_file = open(kwargs['dot'], 'r')
try:
    payload = dot_file.read()
finally:
    dot_file.close()
```

## Testing

- `pytest tests/test_topology.py`: 16 passed (with fix).
- Full suite `pytest tests`: 716 passed, 13 failed — identical 13 failures with the fix stashed, so they are pre-existing and unrelated (all in `tests/tests_v2/test_endpoints/test_simulations.py` and `tests/tests_v2/test_air_model.py`).

## Why existing tests missed it

`test_create_dot_file_path` patches `builtins.open` with a `MagicMock`, so no real file descriptor is ever opened in tests and the leak is invisible. The mock also asserts the exact `open(path, 'r')` call, which this fix preserves.